### PR TITLE
Fix undefined error function

### DIFF
--- a/query-builder-elasticsearch.js
+++ b/query-builder-elasticsearch.js
@@ -60,7 +60,10 @@
                 }
 
                 if (['AND', 'OR'].indexOf(data.condition.toUpperCase()) === -1) {
-                    error('Unable to build Elasticsearch bool query with condition "{0}"', data.condition);
+                    throw new Error(
+                        'Unable to build Elasticsearch bool query with condition "{0}"'
+                        .replace('{0}', data.condition)
+                    );
                 }
 
                 if (!data.rules) {
@@ -89,7 +92,10 @@
                         part = {};
 
                         if (mdb === undefined) {
-                            error('Unknown elasticsearch operation for operator "{0}"', rule.operator);
+                            throw new Error(
+                                'Unknown elasticsearch operation for operator "{0}"'
+                                .replace('{0}', rule.operator)
+                            );
                         }
 
                         if (ope.nb_inputs !== 0) {


### PR DESCRIPTION
Replace calls to undefined [`error`](https://github.com/mistic100/jQuery-QueryBuilder/blob/3d22c191e7b4afad511386904de9f1e720d74ac1/src/utils.js#L50-L61) function with direct `throw` statements.

Note: I left the minified file untouched. Let me know if you want it updated, and if so, what you're using for that.
